### PR TITLE
Fixes and tweaks

### DIFF
--- a/lua/pac3/editor/client/init.lua
+++ b/lua/pac3/editor/client/init.lua
@@ -102,8 +102,10 @@ function pace.OpenEditor()
 
 	pace.SetLanguage()
 
+	local editorWidth = 280
+
 	local editor = pace.CreatePanel("editor")
-		editor:SetSize(240, ScrH())
+		editor:SetSize(editorWidth, ScrH())
 		editor:MakePopup()
 		--editor:SetPos(0, 0)
 		editor.Close = function()
@@ -117,7 +119,7 @@ function pace.OpenEditor()
 	if remember:GetBool() then
 		local x = cookie.GetNumber("pac_editor_x", 0)
 
-		if x < 0 or x + 240 > ScrW() then
+		if x < 0 or x + editorWidth > ScrW() then
 			x = 0
 		end
 
@@ -127,9 +129,9 @@ function pace.OpenEditor()
 		local mode = positionMode:GetInt()
 
 		if mode == 1 then
-			editor:SetPos(ScrW() / 2 - 120, 0)
+			editor:SetPos(ScrW() / 2 - editorWidth / 2, 0)
 		elseif mode == 2 then
-			editor:SetPos(ScrW() - 240, 0)
+			editor:SetPos(ScrW() - editorWidth, 0)
 		else
 			editor:SetPos(0, 0)
 		end

--- a/lua/pac3/editor/client/settings.lua
+++ b/lua/pac3/editor/client/settings.lua
@@ -31,4 +31,4 @@ end
 
 concommand.Add("pace_settings", function()
 	pace.OpenSettings()
-end)
+end, nil, "Open pac3 settings menu (wear whitelist/blacklist)")

--- a/lua/pac3/editor/client/wear_filter.lua
+++ b/lua/pac3/editor/client/wear_filter.lua
@@ -326,17 +326,19 @@ function pace.FillWearSettings(pnl)
 				mode.form:Remove()
 			end
 
+			-- create form based on selection
 			if value == "steam friends" then
 				mode.form = generic_form(L"Only your steam friends can see your worn outfit.")
 			elseif value == "whitelist" then
 				mode.form = player_list_form(L"whitelist", "wear_whitelist", L"Only the players in the whitelist can see your worn outfit.")
 			elseif value == "blacklist" then
 				mode.form = player_list_form( L"blacklist", "wear_blacklist", L"The players in the blacklist cannot see your worn outfit.")
-			else
+			else -- make sure we stay as one of these options
 				value = "disabled"
 				mode.form = generic_form(L"Everyone can see your worn outfit.")
 			end
 
+			-- and set cvar to update filter
 			GetConVar("pace_wear_filter_mode"):SetString(value:gsub(" ", "_"))
 
 			mode.form:SetParent(list)
@@ -367,17 +369,19 @@ function pace.FillWearSettings(pnl)
 				mode.form:Remove()
 			end
 
+			-- create form based on selection
 			if value == "steam friends" then
 				mode.form = generic_form(L"You will only see outfits from your steam friends.")
 			elseif value == "whitelist" then
 				mode.form = player_list_form(L"whitelist", "outfit_whitelist", L"You will only see outfits from the players in the whitelist.")
 			elseif value == "blacklist" then
 				mode.form = player_list_form(L"blacklist", "outfit_blacklist", L"You will see outfits from everyone except the players in the blacklist.")
-			else
+			else -- make sure we stay as one of these options
 				value = "disabled"
 				mode.form = generic_form(L"You will see everyone's outfits.")
 			end
 
+			-- and set cvar to update filter
 			GetConVar("pace_outfit_filter_mode"):SetString(value:gsub(" ", "_"))
 
 			mode.form:SetParent(list)

--- a/lua/pac3/editor/client/wear_filter.lua
+++ b/lua/pac3/editor/client/wear_filter.lua
@@ -332,7 +332,8 @@ function pace.FillWearSettings(pnl)
 				mode.form = player_list_form(L"whitelist", "wear_whitelist", L"Only the players in the whitelist can see your worn outfit.")
 			elseif value == "blacklist" then
 				mode.form = player_list_form( L"blacklist", "wear_blacklist", L"The players in the blacklist cannot see your worn outfit.")
-			elseif value == "disabled" then
+			else
+				value = "disabled"
 				mode.form = generic_form(L"Everyone can see your worn outfit.")
 			end
 
@@ -372,7 +373,8 @@ function pace.FillWearSettings(pnl)
 				mode.form = player_list_form(L"whitelist", "outfit_whitelist", L"You will only see outfits from the players in the whitelist.")
 			elseif value == "blacklist" then
 				mode.form = player_list_form(L"blacklist", "outfit_blacklist", L"You will see outfits from everyone except the players in the blacklist.")
-			elseif value == "disabled" then
+			else
+				value = "disabled"
 				mode.form = generic_form(L"You will see everyone's outfits.")
 			end
 


### PR DESCRIPTION
Dont spam errors if pac blacklist settings cvars are invalid

Widen editor when opening it so it always displays "tools" on the pac menu bar
<img width="411" height="407" alt="image" src="https://github.com/user-attachments/assets/b4846430-fe57-4d23-95d3-9cc5867f0b3d" />
<img width="455" height="377" alt="image" src="https://github.com/user-attachments/assets/7e75c85f-030f-4199-a849-c217b17a6d33" />
